### PR TITLE
Changed return type of race to void

### DIFF
--- a/exercises/concept/remote-control-competition/src/main/java/TestTrack.java
+++ b/exercises/concept/remote-control-competition/src/main/java/TestTrack.java
@@ -2,7 +2,7 @@ import java.util.List;
 
 public class TestTrack {
 
-    public static double race(RemoteControlCar car) {
+    public static void race(RemoteControlCar car) {
         throw new UnsupportedOperationException("Please implement the (static) TestTrack.race() method");
     }
 


### PR DESCRIPTION
There's no indication in the examples that TestTrack.race returns anything.... and doesn't make sense given all the other possible return values given the set of other potential return variables all have type int.

# pull request

<!-- Your content goes here: -->



<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/master/POLICIES.md#event-checklist)
